### PR TITLE
Added support for debugging Node.js code

### DIFF
--- a/src/JavaScriptViewEngine/NodeRenderEngine.cs
+++ b/src/JavaScriptViewEngine/NodeRenderEngine.cs
@@ -32,7 +32,9 @@ namespace JavaScriptViewEngine
             {
                 ProjectPath = options.ProjectDirectory,
                 WatchFileExtensions = options.WatchFileExtensions,
-                EnvironmentVariables = options.EnvironmentVariables
+                EnvironmentVariables = options.EnvironmentVariables,
+                DebuggingPort = options.DebuggingPort,
+                LaunchWithDebugging = options.LaunchWithDebugging
             };
 
 	        if (options.NodeInstanceFactory != null)

--- a/src/JavaScriptViewEngine/NodeRenderEngineOptions.cs
+++ b/src/JavaScriptViewEngine/NodeRenderEngineOptions.cs
@@ -56,7 +56,17 @@ namespace JavaScriptViewEngine
         /// If set, starts the Node.js instance with the specified environment variables.
         /// </summary>
         public IDictionary<string, string> EnvironmentVariables { get; set; }
-    }
+
+        /// <summary>
+        /// If true, the Node.js instance will accept incoming V8 debugger connections (e.g., from node-inspector).
+        /// </summary>
+        public bool LaunchWithDebugging { get; set; }
+
+        /// <summary>
+        /// If <see cref="LaunchWithDebugging"/> is true, the Node.js instance will listen for V8 debugger connections on this port.
+        /// </summary>
+        public int DebuggingPort { get; set; }
+     }
 
     public delegate string GetModuleNameDelegate(string path, object model, dynamic viewBag, RouteValueDictionary routeValues, string area, ViewType viewType);
 }


### PR DESCRIPTION
Added support for debugging Node.js code:

```
services.AddJsEngine(builder =>
{
    builder.UseNodeRenderEngine(options =>
    {
        :
        options.LaunchWithDebugging = true;
        options.DebuggingPort = 9229;
    });
    :
});
```